### PR TITLE
提供事件回调接口，使得其他js可以调用mvu功能进行变量更新

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -1032,13 +1032,15 @@ export async function handleVariablesInMessage(message_id: number) {
 
 
 export async function handleVariablesInCallback(messageContent: string, variableInfo : VariableData) {
-    if (variableInfo.oldVariable === undefined)
+    if (variableInfo.oldVariables === undefined)
     {
-        variableInfo.modified = false;
         return;
     }
-    variableInfo.newVariable = _.cloneDeep(variableInfo.oldVariable);
-    const variables = variableInfo.newVariable;
+    variableInfo.newVariables = _.cloneDeep(variableInfo.oldVariables);
+    const variables = variableInfo.newVariables;
 
-    variableInfo.modified = await updateVariables(messageContent, variables);
+    const modified = await updateVariables(messageContent, variables);
+    //如果没有修改，则不产生 newVariable
+    if (!modified)
+        delete variableInfo.newVariables;
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -1,4 +1,4 @@
-import {variable_events} from '@/variable_def';
+import {variable_events, VariableData} from '@/variable_def';
 import * as math from 'mathjs';
 
 import {getSchemaForPath, reconcileAndApplySchema} from "@/schema";
@@ -92,8 +92,7 @@ export function parseCommandValue(valStr: string): any {
     try {
         // 尝试 YAML.parse
         return YAML.parse(trimmed);
-    } catch (e) {
-    }
+    } catch (e) { /* empty */ }
 
     // 最终，返回这个去除了首尾引号的字符串
     return trimQuotesAndBackslashes(valStr);
@@ -1028,4 +1027,18 @@ export async function handleVariablesInMessage(message_id: number) {
             }
         );
     }
+}
+
+
+
+export async function handleVariablesInCallback(message_content: string, variableInfo : VariableData) {
+    if (variableInfo.oldVariable === undefined)
+    {
+        variableInfo.modified = false;
+        return;
+    }
+    variableInfo.newVariable = _.cloneDeep(variableInfo.oldVariable);
+    const variables = variableInfo.newVariable;
+
+    variableInfo.modified = await updateVariables(message_content, variables);
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -1032,15 +1032,15 @@ export async function handleVariablesInMessage(message_id: number) {
 
 
 export async function handleVariablesInCallback(message_content: string, variable_info : VariableData) {
-    if (variable_info.oldVariables === undefined)
+    if (variable_info.old_variables === undefined)
     {
         return;
     }
-    variable_info.newVariables = _.cloneDeep(variable_info.oldVariables);
-    const variables = variable_info.newVariables;
+    variable_info.new_variables = _.cloneDeep(variable_info.old_variables);
+    const variables = variable_info.new_variables;
 
     const modified = await updateVariables(message_content, variables);
     //如果没有修改，则不产生 newVariable
     if (!modified)
-        delete variable_info.newVariables;
+        delete variable_info.new_variables;
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -1031,16 +1031,16 @@ export async function handleVariablesInMessage(message_id: number) {
 
 
 
-export async function handleVariablesInCallback(messageContent: string, variableInfo : VariableData) {
-    if (variableInfo.oldVariables === undefined)
+export async function handleVariablesInCallback(message_content: string, variable_info : VariableData) {
+    if (variable_info.oldVariables === undefined)
     {
         return;
     }
-    variableInfo.newVariables = _.cloneDeep(variableInfo.oldVariables);
-    const variables = variableInfo.newVariables;
+    variable_info.newVariables = _.cloneDeep(variable_info.oldVariables);
+    const variables = variable_info.newVariables;
 
-    const modified = await updateVariables(messageContent, variables);
+    const modified = await updateVariables(message_content, variables);
     //如果没有修改，则不产生 newVariable
     if (!modified)
-        delete variableInfo.newVariables;
+        delete variable_info.newVariables;
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -1031,7 +1031,7 @@ export async function handleVariablesInMessage(message_id: number) {
 
 
 
-export async function handleVariablesInCallback(message_content: string, variableInfo : VariableData) {
+export async function handleVariablesInCallback(messageContent: string, variableInfo : VariableData) {
     if (variableInfo.oldVariable === undefined)
     {
         variableInfo.modified = false;
@@ -1040,5 +1040,5 @@ export async function handleVariablesInCallback(message_content: string, variabl
     variableInfo.newVariable = _.cloneDeep(variableInfo.oldVariable);
     const variables = variableInfo.newVariable;
 
-    variableInfo.modified = await updateVariables(message_content, variables);
+    variableInfo.modified = await updateVariables(messageContent, variables);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,13 @@
-import {handleVariablesInMessage} from '@/function';
+import {handleVariablesInMessage, handleVariablesInCallback} from '@/function';
 import {initCheck} from '@/variable_init';
+import {variable_events} from "@/variable_def";
 
 $(() => {
     eventOn(tavern_events.GENERATION_STARTED, initCheck);
     eventOn(tavern_events.MESSAGE_SENT, initCheck);
     eventOn(tavern_events.MESSAGE_SENT, handleVariablesInMessage);
     eventOn(tavern_events.MESSAGE_RECEIVED, handleVariablesInMessage);
+    eventOn(variable_events.INVOKE_MVU_PROCESS, handleVariablesInCallback);
 
     // 导出到窗口，便于调试
     _.set(window, 'handleVariablesInMessage', handleVariablesInMessage);

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,4 +18,5 @@ $(window).on('unload', () => {
     eventRemoveListener(tavern_events.MESSAGE_SENT, initCheck);
     eventRemoveListener(tavern_events.MESSAGE_SENT, handleVariablesInMessage);
     eventRemoveListener(tavern_events.MESSAGE_RECEIVED, handleVariablesInMessage);
+    eventRemoveListener(variable_events.INVOKE_MVU_PROCESS, handleVariablesInCallback);
 });

--- a/src/variable_def.ts
+++ b/src/variable_def.ts
@@ -13,9 +13,11 @@ export type GameData = {
 
 export interface VariableData
 {
-    oldVariable: GameData,
-    newVariable?: GameData,
-    modified?: boolean
+    oldVariables: GameData,
+    /**
+     * 输出变量，仅当实际产生了变量变更的场合，会产生 newVariables
+     */
+    newVariables?: GameData
 }
 
 export const variable_events = {

--- a/src/variable_def.ts
+++ b/src/variable_def.ts
@@ -14,8 +14,8 @@ export type GameData = {
 export interface VariableData
 {
     oldVariable: GameData,
-    newVariable: GameData,
-    modified: boolean
+    newVariable?: GameData,
+    modified?: boolean
 }
 
 export const variable_events = {

--- a/src/variable_def.ts
+++ b/src/variable_def.ts
@@ -39,5 +39,5 @@ export type ExtendedListenerType = {
             out_is_updated: boolean
     ) => void;
     [variable_events.VARIABLE_UPDATE_ENDED]: (variables: GameData, out_is_updated: boolean) => void;
-    [variable_events.INVOKE_MVU_PROCESS]: (message_content: string, variableInfo : VariableData) => void;
+    [variable_events.INVOKE_MVU_PROCESS]: (message_content: string, variable_info : VariableData) => void;
 };

--- a/src/variable_def.ts
+++ b/src/variable_def.ts
@@ -13,11 +13,11 @@ export type GameData = {
 
 export interface VariableData
 {
-    oldVariables: GameData,
+    old_variables: GameData,
     /**
      * 输出变量，仅当实际产生了变量变更的场合，会产生 newVariables
      */
-    newVariables?: GameData
+    new_variables?: GameData
 }
 
 export const variable_events = {

--- a/src/variable_def.ts
+++ b/src/variable_def.ts
@@ -11,10 +11,18 @@ export type GameData = {
     schema: Record<string, any>;
 };
 
+export interface VariableData
+{
+    oldVariable: GameData,
+    newVariable: GameData,
+    modified: boolean
+}
+
 export const variable_events = {
     SINGLE_VARIABLE_UPDATED: 'mag_variable_updated',
     VARIABLE_UPDATE_ENDED: 'mag_variable_update_ended',
     VARIABLE_UPDATE_STARTED: 'mag_variable_update_started',
+    INVOKE_MVU_PROCESS: 'mag_invoke_mvu'
 } as const;
 
 export type ExtendedListenerType = {
@@ -29,4 +37,5 @@ export type ExtendedListenerType = {
             out_is_updated: boolean
     ) => void;
     [variable_events.VARIABLE_UPDATE_ENDED]: (variables: GameData, out_is_updated: boolean) => void;
+    [variable_events.INVOKE_MVU_PROCESS]: (message_content: string, variableInfo : VariableData) => void;
 };

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -1,4 +1,5 @@
-import { parseParameters, trimQuotesAndBackslashes } from '../src/function';
+import {handleVariablesInCallback, parseParameters, trimQuotesAndBackslashes} from '@/function';
+import {VariableData} from "@/variable_def";
 
 describe('parseParameters', () => {
     describe('基本参数解析', () => {
@@ -196,5 +197,29 @@ describe('trimQuotesAndBackslashes', () => {
 
     test('处理仅空格', () => {
         expect(trimQuotesAndBackslashes('   ')).toBe('');
+    });
+});
+
+describe('invokeVariableTest', () => {
+    test('should update variable value', async () => {
+        const inputData : VariableData = {
+            oldVariable: {
+                initialized_lorebooks: {},
+                stat_data: {"喵呜": 20},
+                display_data: {},
+                delta_data: {},
+                schema: {}
+            },
+            newVariable: {
+                initialized_lorebooks: {},
+                stat_data: {},
+                display_data: {},
+                delta_data: {},
+                schema: {}
+            },
+            modified: false
+        };
+        await handleVariablesInCallback("_.set('喵呜', 114);//测试", inputData);
+        expect(inputData.newVariable.stat_data.喵呜).toBe(114);
     });
 });

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -203,7 +203,7 @@ describe('trimQuotesAndBackslashes', () => {
 describe('invokeVariableTest', () => {
     test('should update variable value', async () => {
         const inputData : VariableData = {
-            oldVariable: {
+            oldVariables: {
                 initialized_lorebooks: {},
                 stat_data: {"喵呜": 20},
                 display_data: {},
@@ -212,9 +212,21 @@ describe('invokeVariableTest', () => {
             }
         };
         await handleVariablesInCallback("_.set('喵呜', 114);//测试", inputData);
-        expect(inputData.newVariable).not.toBeUndefined();
-        expect(inputData.newVariable!.stat_data.喵呜).toBe(114);
-        expect(inputData.oldVariable.stat_data.喵呜).toBe(20);
-        expect(inputData.modified).toBe(true);
+        expect(inputData.newVariables).not.toBeUndefined();
+        expect(inputData.newVariables!.stat_data.喵呜).toBe(114);
+        expect(inputData.oldVariables.stat_data.喵呜).toBe(20);
+    });
+    test('expect not updated', async () => {
+        const inputData : VariableData = {
+            oldVariables: {
+                initialized_lorebooks: {},
+                stat_data: {"喵呜": 20},
+                display_data: {},
+                delta_data: {},
+                schema: {}
+            }
+        };
+        await handleVariablesInCallback("这是一个没有更新的文本。明天见是最好的预言。", inputData);
+        expect(inputData.newVariables).toBeUndefined();
     });
 });

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -203,7 +203,7 @@ describe('trimQuotesAndBackslashes', () => {
 describe('invokeVariableTest', () => {
     test('should update variable value', async () => {
         const inputData : VariableData = {
-            oldVariables: {
+            old_variables: {
                 initialized_lorebooks: {},
                 stat_data: {"喵呜": 20},
                 display_data: {},
@@ -212,13 +212,13 @@ describe('invokeVariableTest', () => {
             }
         };
         await handleVariablesInCallback("_.set('喵呜', 114);//测试", inputData);
-        expect(inputData.newVariables).not.toBeUndefined();
-        expect(inputData.newVariables!.stat_data.喵呜).toBe(114);
-        expect(inputData.oldVariables.stat_data.喵呜).toBe(20);
+        expect(inputData.new_variables).not.toBeUndefined();
+        expect(inputData.new_variables!.stat_data.喵呜).toBe(114);
+        expect(inputData.old_variables.stat_data.喵呜).toBe(20);
     });
     test('expect not updated', async () => {
         const inputData : VariableData = {
-            oldVariables: {
+            old_variables: {
                 initialized_lorebooks: {},
                 stat_data: {"喵呜": 20},
                 display_data: {},
@@ -227,6 +227,6 @@ describe('invokeVariableTest', () => {
             }
         };
         await handleVariablesInCallback("这是一个没有更新的文本。明天见是最好的预言。", inputData);
-        expect(inputData.newVariables).toBeUndefined();
+        expect(inputData.new_variables).toBeUndefined();
     });
 });

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -221,5 +221,7 @@ describe('invokeVariableTest', () => {
         };
         await handleVariablesInCallback("_.set('喵呜', 114);//测试", inputData);
         expect(inputData.newVariable.stat_data.喵呜).toBe(114);
+        expect(inputData.oldVariable.stat_data.喵呜).toBe(20);
+        expect(inputData.modified).toBe(true);
     });
 });

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -209,18 +209,11 @@ describe('invokeVariableTest', () => {
                 display_data: {},
                 delta_data: {},
                 schema: {}
-            },
-            newVariable: {
-                initialized_lorebooks: {},
-                stat_data: {},
-                display_data: {},
-                delta_data: {},
-                schema: {}
-            },
-            modified: false
+            }
         };
         await handleVariablesInCallback("_.set('喵呜', 114);//测试", inputData);
-        expect(inputData.newVariable.stat_data.喵呜).toBe(114);
+        expect(inputData.newVariable).not.toBeUndefined();
+        expect(inputData.newVariable!.stat_data.喵呜).toBe(114);
         expect(inputData.oldVariable.stat_data.喵呜).toBe(20);
         expect(inputData.modified).toBe(true);
     });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -7,6 +7,11 @@ import * as _ from 'lodash';
 // Mock window object
 (globalThis as any).window = globalThis;
 
+// Mock TavernHelper
+(globalThis as any).window.TavernHelper = {
+  substitudeMacros: jest.fn(input => input),
+};
+
 // Mock tavern events
 (globalThis as any).tavern_events = {
   GENERATION_ENDED: 'GENERATION_ENDED',
@@ -24,3 +29,4 @@ import * as _ from 'lodash';
 (globalThis as any).setChatMessage = jest.fn();
 (globalThis as any).getCurrentCharPrimaryLorebook = jest.fn();
 (globalThis as any).getAvailableLorebooks = jest.fn();
+(globalThis as any).substitudeMacros = jest.fn(input => input);


### PR DESCRIPTION
https://github.com/MagicalAstrogy/MagVarUpdate/issues/11

增加新事件：`mag_invoke_mvu`
```
export interface VariableData
{
    old_variables: GameData,
    /**
     * 输出变量，仅当实际产生了变量变更的场合，会产生 newVariables
     */
    new_variables?: GameData
}
```
`[variable_events.INVOKE_MVU_PROCESS]: (message_content: string, variableInfo : VariableData) => void`

使用方式：
```
const inputData  = {
            old_variables: {
                initialized_lorebooks: {},
                stat_data: {"喵呜": 20},
                display_data: {},
                delta_data: {},
                schema: {}
            },//老的状态
        };
await eventEmit('mag_invoke_mvu', "_.set('喵呜', 114);//测试", inputData);
//调用之后，会更新变量信息，并保存到 `newVariables` 中。
//在这之后你会发现 inputData.new_variables.stat_data.喵呜 == 114
//如果没有产生任何更新，则会是 new_variables会是 undefined
```