### PR TITLE
fix: root key removal

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -693,7 +693,8 @@ export async function updateVariables(
                     );
                     continue;
                 }
-                if (!_.has(variables.stat_data, containerPath)) {
+                // 只有当容器路径不是根路径（即不为空）时，才检查其是否存在
+                if (containerPath !== '' && !_.has(variables.stat_data, containerPath)) {
                     console.warn(
                         `Cannot remove from non-existent path '${containerPath}'. ${reason_str}`
                     );


### PR DESCRIPTION
`WARN Cannot remove from non-existent path ''.`
当试图删除一个位于顶层的键时会操作失败，这是因为remove命令没有正确处理空字符串路径（即顶层节点的父节点）