### PR TITLE
fix: 修复循环引用问题

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -339,7 +339,6 @@ export async function updateVariables(
     const delta_status: Record<string, any> = { stat_data: {} };
     const matched_set = extractSetCommands(current_message_content);
     variables.stat_data.$internal = {
-        stat_data: variables.stat_data,
         display_data: out_status.stat_data,
         delta_data: delta_status.stat_data,
     };

--- a/src/variable_def.ts
+++ b/src/variable_def.ts
@@ -64,7 +64,8 @@ export const exported_events = {
 };
 
 export type InternalData = {
-    stat_data: Record<string, any>;
+    //不存自己，会导致环形引用
+    //stat_data: Record<string, any>;
     display_data: Record<string, any>;
     delta_data: Record<string, any>;
 };


### PR DESCRIPTION
因为在 eventEmit 时，酒馆助手会将参数进行一次序列化，因此不允许参数中存在循环引用。

这个 pr 修复了存在的循环引用，以便正常执行