### PR TITLE
fix: 修正部分情况下变量的获取值是非确定的问题。

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -1210,9 +1210,14 @@ export async function handleVariablesInMessage(message_id: number) {
     }
 
     let message_content = chat_message.message;
-    const variables = await getLastValidVariable(message_id);
+
+    if (message_content.length < 5)
+        //MESSAGE_RECEIVED会递交一个 "..." 的消息
+        return;
+    const request_message_id = message_id === 0 ? 0 : message_id - 1;
+    const variables = await getLastValidVariable(request_message_id);
     if (!_.has(variables, 'stat_data')) {
-        console.error(`cannot found stat_data for ${message_id}`);
+        console.error(`cannot found stat_data for ${request_message_id}`);
         return;
     }
 


### PR DESCRIPTION
两个问题：
1. 在聊天开始时会发送一个消息为 "..." 状态时的 MESSAGE_RECEIVED 事件，我没过滤，导致当前层的信息非空了。而在网页被切到后台/被打断点的场合，会导致同时处理两个 MESSAGE_RECEIVED 事件的回调，会出问题吗？
2. 聊天处理是以最近一层的变量为基准的（即包含“当前层”），这会导致结果有时不太稳定。