### PR TITLE
Cherry pick fix: 覆盖旧变量而非与旧变量合并 (#96)

### DIFF
--- a/src/variable_init.ts
+++ b/src/variable_init.ts
@@ -118,7 +118,7 @@ export async function initCheck() {
     }
 
     console.info(`Init chat variables.`);
-    await insertOrAssignVariables(variables);
+    await updateVariablesWith(data => _.assign(data, variables));
 
     if (getLastMessageId() == 0) {
         const last_msg = getChatMessages(0, { include_swipes: true })[0];


### PR DESCRIPTION
## Summary
- update message variable synchronization to assign values via `updateVariablesWith`
- switch init variable setup to use assignment-based updates
- align handleVariablesInMessage tests with the new update strategy

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68d52c7876508331866061c2b02ef645