### PR TITLE
ci: 自动将 beta 镜像到 master 分支

### DIFF
--- a/.github/workflows/bundle.yaml
+++ b/.github/workflows/bundle.yaml
@@ -1,65 +1,78 @@
 name: bundle
 
 on:
-  push:
-    branches: [ master, beta ]
-    paths-ignore:
-      - artifact/**
-  workflow_dispatch:
+    push:
+        branches:
+            - master
+        paths-ignore:
+            - artifact/**
+    workflow_dispatch:
+
+permissions:
+    actions: read
+    contents: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}
 
 jobs:
-  compile:
-    runs-on: ubuntu-latest
+    compile:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ssh-key: ${{ secrets.CI_DEPLOY_KEY }}
-          fetch-depth: 0                 # ← 必须
-          submodules: 'recursive'
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ssh-key: ${{ secrets.GITHUB_TOKEN }}
+                  fetch-depth: 0 # ← 必须
+                  submodules: 'recursive'
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      -   name: Corepack & Yarn
-          run: |
-              corepack enable
-              corepack prepare yarn@3.4.1 --activate
-              if [ -f yarn.lock ]; then
-                echo "🔒 Lockfile exists, using immutable install"
-                yarn install --immutable
-              else
-                echo "⚠️  Lockfile missing, generating..."
-                yarn install
-              fi
-      - name: format Code
-        run: yarn format
-      - run: yarn build
-      - name: Commit changes
-        uses: EndBug/add-and-commit@v9.1.3
-        with:
-          default_author: github_actions
-          message: '[bot] Bundle'
+            - name: Use Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+            - name: Corepack & Yarn
+              run: |
+                  corepack enable
+                  corepack prepare yarn@3.4.1 --activate
+                  if [ -f yarn.lock ]; then
+                    echo "🔒 Lockfile exists, using immutable install"
+                    yarn install --immutable
+                  else
+                    echo "⚠️  Lockfile missing, generating..."
+                    yarn install
+                  fi
+            - name: format Code
+              run: yarn format
+            - run: yarn build
+            - name: Commit changes
+              uses: EndBug/add-and-commit@v9.1.3
+              with:
+                  default_author: github_actions
+                  message: '[bot] Bundle'
 
-  bump_tag:
-      runs-on: ubuntu-latest
-      needs: compile
-      steps:
+    sync:
+        runs-on: ubuntu-latest
+        needs: compile
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  fetch-depth: 0
+            - run: git push origin beta:master -f
 
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0                 # ← 必须
+    bump_tag:
+        runs-on: ubuntu-latest
+        needs: sync
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  fetch-depth: 0 # ← 必须
 
-      - name: Github Tag Bump
-        uses: anothrNick/github-tag-action@1.73.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_PREFIX: v
-          RELEASE_BRANCHES: master      # 仅 master 产正式版
-          PRERELEASE_SUFFIX: beta       # beta 分支自动变成 vX.Y.Z-beta.N
+            - name: Github Tag Bump
+              uses: anothrNick/github-tag-action@1.73.0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  TAG_PREFIX: v
+                  RELEASE_BRANCHES: master
+


### PR DESCRIPTION
原因：
- 显然 master 也需要`额外模型解析`等新功能
- 一些教程里还是使用的 `@master` 链接，因此还可能有用 master 的卡产生