### PR TITLE
fix: 让 JSONPatch 标签匹配更泛化

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -241,7 +241,7 @@ interface Command {
  */
 // 将 extractSetCommands 扩展为 extractCommands 以支持多种命令
 export function extractCommands(inputText: string): Command[] {
-    const jsonPatchMatch = inputText.match(/<JSONPatch>([\s\S]*?)<\/JSONPatch>/);
+    const jsonPatchMatch = inputText.match(/<json_?patch>([\s\S]*?)<\/json_?patch>/i);
     if (jsonPatchMatch && jsonPatchMatch[1]) {
         try {
             const patch = JSON.parse(jsonPatchMatch[1]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,7 +254,7 @@ async function onMessageReceived(message_id: number) {
                     /_\.(?:set|insert|assign|remove|unset|delete|add)\s*\([\s\S]*?\)\s*;/.test(
                         last_content
                     );
-                const json_patch_pattern = /jsonpatch/i;
+                const json_patch_pattern = /json_?patch/i;
                 const json_patch_match = last_content.match(json_patch_pattern);
                 if (fn_call_match || json_patch_match !== null) {
                     result = `<UpdateVariable>${last_content}</UpdateVariable>`;


### PR DESCRIPTION
兼容 `<JSONPatch>`、`<jsonpatch>`、`<json_patch>` 等情况