### PR TITLE
fix: 修正在新聊天的场合会触发额外模型解析的问题

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -117,6 +117,11 @@ async function onMessageReceived(message_id: number) {
         return;
     }
 
+    if (SillyTavern.chat.length <= 1) {
+        console.log('[MVU] 对第一层永不进行额外模型解析');
+        return;
+    }
+
     duringExtraCall = true;
     let user_input = ExtraLLMRequestContent;
     if (settings.额外模型解析配置.使用函数调用) {


### PR DESCRIPTION
如题，应该是在 4.x 酒馆助手下专有的，会有一个 message_received 事件

我考虑了下，应该不存在 1 层且有 llm 回复的情况。

已自测。