### PR TITLE
ci: 为最新 commit 添加 tag

### DIFF
--- a/.github/workflows/bundle.yaml
+++ b/.github/workflows/bundle.yaml
@@ -52,19 +52,8 @@ jobs:
       - name: Mirror to master
         run: git push origin beta:master -f
 
-  bump_tag:
-    runs-on: ubuntu-latest
-    needs: compile
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0 # ← 必须
-
       - name: Github Tag Bump
         uses: anothrNick/github-tag-action@1.73.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_PREFIX: v
-          RELEASE_BRANCHES: master # 仅 master 产正式版
-          PRERELEASE_SUFFIX: beta # beta 分支自动变成 vX.Y.Z-beta.N


### PR DESCRIPTION
之前的 ci 可能对提交时的最新 commit 而非 ci 中更新的 `[bot] Bundle` 添加 tag，导致 jsdelivr 更新延迟