### PR TITLE
Revert "feat: 额外模型解析不再需要 1.13.4 及以上"

### DIFF
--- a/src/panel/Update.vue
+++ b/src/panel/Update.vue
@@ -24,6 +24,23 @@ import Request from '@/panel/update/Request.vue';
 import Source from '@/panel/update/Source.vue';
 import update_method_help from '@/panel/update_method.md';
 import { useDataStore } from '@/store';
+import { getSillyTavernVersion } from '@/util';
+import { compare } from 'compare-versions';
+import { watch } from 'vue';
 
 const store = useDataStore();
+
+watch(
+    () => store.settings.更新方式,
+    value => {
+        if (value === '额外模型解析' && compare(getSillyTavernVersion(), '1.13.4', '<')) {
+            toastr.error(
+                "检查到酒馆版本过低，要使用'额外模型解析'请保证酒馆版本大于等于 1.13.4",
+                "[MVU]无法使用'额外模型解析'",
+                { timeOut: 5000 }
+            );
+            store.settings.更新方式 = '随AI输出';
+        }
+    }
+);
 </script>


### PR DESCRIPTION
TLDR: 我是猪鼻，光想到 1.13.5 提示词模板的 dry run 不需要考虑了，忘了筛选发送出去的世界书条目要 1.13.4