### PR TITLE
feat: 对 BEFORE_MESSAGE_UPDATE 提供更多楼层信息

### DIFF
--- a/src/function/update_variables.ts
+++ b/src/function/update_variables.ts
@@ -1438,12 +1438,15 @@ export async function handleVariablesInMessage(message_id: number) {
     if (!_.has(variables, 'stat_data')) {
         return;
     }
+    const swipe_id = SillyTavern.chat[message_id]?.swipe_id??0;
 
     const has_variable_modified = await updateVariables(message_content, variables);
     if (has_variable_modified && chat_message.role !== 'user') {
         const context: UpdateContext = {
-            variables: variables,
-            message_content: message_content,
+            variables,
+            message_id,
+            swipe_id,
+            message_content,
         };
         await eventEmit(variable_events.BEFORE_MESSAGE_UPDATE, context);
         message_content = context.message_content;

--- a/src/variable_def.ts
+++ b/src/variable_def.ts
@@ -243,6 +243,8 @@ export const variable_events = {
 
 export type UpdateContext = {
     variables: MvuData;
+    message_id: number;
+    swipe_id: number;
     message_content: string;
 };
 


### PR DESCRIPTION
在 `BEFORE_MESSAGE_UPDATE` 事件额外提供 message_id 和 swipe_id 便于判断某个楼层更新完成
但是开场白是不是不一定触发这个（

---
相关：https://discord.com/channels/1134557553011998840/1400321862235328552/1525581198036832407